### PR TITLE
feat: 쿠키 기반 JWT 인증 방식 적용 및 로그인 흐름 변경

### DIFF
--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -6,7 +6,7 @@ interface JwtPayload {
 }
 
 export const authenticate: RequestHandler = (req, res, next) => {
-  const token = req.cookies?.token; // 쿠키에서 토큰 추출
+  const token = req.cookies?.token;
 
   if (!token) {
     res.status(401).json({ message: "토큰이 없습니다." });
@@ -15,7 +15,7 @@ export const authenticate: RequestHandler = (req, res, next) => {
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;
-    req.user = { id: decoded.id }; // 명시적으로 객체 할당
+    req.user = { id: decoded.id };
     next();
   } catch {
     res.status(401).json({ message: "유효하지 않은 토큰입니다." });


### PR DESCRIPTION
## 개요

- 기존 로그인 시 JWT를 응답으로 반환하던 방식에서, 쿠키(`httpOnly`)에 저장하는 방식으로 전환
- 프론트엔드는 쿠키 기반 인증 흐름을 사용하며, Authorization 헤더 설정이 필요 없어짐

---

## 작업 내용

- `auth.service.ts`: 로그인 시 JWT 토큰을 생성만 하도록 로직 유지
- `auth.controller.ts`: 로그인 성공 시 `res.cookie()`를 통해 JWT를 httpOnly 쿠키로 저장
- `authenticate` 미들웨어: `Authorization` 헤더 → `req.cookies.token`으로 인증 방식 변경

---

## 특이사항

- 프론트엔드 요청 시 `withCredentials: true` 옵션 필요
- 추후 로그아웃 시 `res.clearCookie("token")`으로 로그아웃 처리 가능

---

## 테스트

- Postman으로 로그인 요청 후 Cookies 탭에서 JWT 토큰 확인

