### PR TITLE
refactor: team 서비스 유틸 추출 및 쿼리 정리

### DIFF
--- a/backend/src/controller/todo.controller.ts
+++ b/backend/src/controller/todo.controller.ts
@@ -60,7 +60,7 @@ export const deleteTodo = async (req: Request, res: Response) => {
 
   const deleted = await deleteTodoService(todoId, userId!);
 
-  if (deleted.count === 0) {
+  if (!deleted) {
     res
       .status(StatusCodes.NOT_FOUND)
       .json({ message: "삭제할 Todo를 찾을 수 없습니다." });

--- a/backend/src/lib/jwt.ts
+++ b/backend/src/lib/jwt.ts
@@ -1,0 +1,7 @@
+import jwt from "jsonwebtoken";
+
+export const generateToken = (userId: string) => {
+  return jwt.sign({ id: userId }, process.env.JWT_SECRET!, {
+    expiresIn: "1h",
+  });
+};

--- a/backend/src/lib/password.ts
+++ b/backend/src/lib/password.ts
@@ -1,0 +1,14 @@
+import bcrypt from "bcrypt";
+
+const SALT_ROUNDS = 10;
+
+export const hashPassword = (password: string) => {
+  return bcrypt.hash(password, SALT_ROUNDS);
+};
+
+export const validatePassword = (
+  rawPassword: string,
+  hashedPassword: string
+) => {
+  return bcrypt.compare(rawPassword, hashedPassword);
+};

--- a/backend/src/routes/team.route.ts
+++ b/backend/src/routes/team.route.ts
@@ -12,7 +12,6 @@ import {
   updateTeamTodoStatus,
 } from "../controller/team.controller";
 import { Router } from "express";
-import { StatusCodes } from "http-status-codes";
 import { authenticate } from "../middlewares/auth.middleware";
 
 const router = Router();

--- a/backend/src/routes/todo.route.ts
+++ b/backend/src/routes/todo.route.ts
@@ -6,7 +6,6 @@ import {
   updateTodoContents,
 } from "../controller/todo.controller";
 import { Router } from "express";
-import { StatusCodes } from "http-status-codes";
 import { authenticate } from "../middlewares/auth.middleware";
 
 const router = Router();

--- a/backend/src/services/todo.service.ts
+++ b/backend/src/services/todo.service.ts
@@ -1,13 +1,12 @@
 import { prisma } from "../prisma/client";
 
 export const createTodoService = async (userId: string, contents: string) => {
-  const todo = await prisma.userTodos.create({
+  return prisma.userTodos.create({
     data: {
       userId,
       contents,
     },
   });
-  return todo;
 };
 
 export const getTodosService = async (userId: string) => {
@@ -22,28 +21,29 @@ export const updateTodoContentsService = async (
   userId: string,
   contents: string
 ) => {
-  return prisma.userTodos.updateMany({
-    where: { id: todoId, userId },
+  return prisma.userTodos.update({
+    where: { id: todoId },
     data: { contents },
   });
 };
 
 export const toggleTodoDoneService = async (todoId: number, userId: string) => {
-  const result = await prisma.userTodos.findUnique({
-    where: { id: todoId, userId: userId },
-  });
-  const resultIsdone = !result?.isDone;
-  return prisma.userTodos.updateMany({
+  const todo = await prisma.userTodos.findFirst({
     where: { id: todoId, userId },
-    data: { isDone: resultIsdone },
+  });
+
+  if (!todo) {
+    throw new Error("해당 Todo를 찾을 수 없습니다.");
+  }
+
+  return prisma.userTodos.update({
+    where: { id: todoId },
+    data: { isDone: !todo.isDone },
   });
 };
 
 export const deleteTodoService = async (todoId: number, userId: string) => {
-  return prisma.userTodos.deleteMany({
-    where: {
-      id: todoId,
-      userId,
-    },
+  return prisma.userTodos.delete({
+    where: { id: todoId },
   });
 };

--- a/backend/src/swagger.ts
+++ b/backend/src/swagger.ts
@@ -10,11 +10,11 @@ export const swaggerSpec = swaggerJSDoc({
     },
     servers: [
       {
-        url: "http://localhost:3000", // .env 기반으로 추후 교체 가능 여부
+        url: "http://localhost:3000",
       },
     ],
   },
-  apis: ["./src/routes/*.ts"], // 라우터 파일에 Swagger 주석 작성하면 여기서 읽는다.
+  apis: ["./src/routes/*.ts"],
   components: {
     securitySchemes: {
       bearerAuth: {


### PR DESCRIPTION
## 개요

team 서비스의 중복 로직 제거 및 Prisma 쿼리 명확화를 위한 리팩토링을 진행

---

## 작업 내용

- 유틸 함수 `getTeamAndVerifyAdmin`, `isTeamMember` 도입으로 중복 제거
- `updateMany`, `deleteMany` → `update`, `delete`로 변경하여 명확한 PK 기준 처리
- 불필요한 `findUnique({ id, teamId })` → `findUnique({ id })`로 정리
- status code 및 message 일관성 개선
- 예외 시 반환 구조 통일 (`{ success, status, message }`)

---

## 특이사항

- 현재는 `team.service.ts` 내부에서 유틸을 정의했음. 필요시 utils 확장 가능

---

## 테스트

- 팀 생성, 초대, 삭제, 팀원 강퇴 기능 정상 동작 확인
- 팀 todo 생성/수정/삭제 기능 정상 작동 확인
- Postman를 통한 API 호출 테스트 완료
